### PR TITLE
Copying ARcore values-no to values-nb

### DIFF
--- a/android/app/build/intermediates/exploded-aar/ViroSample/arcore_client/unspecified/res/values-nb/strings.xml
+++ b/android/app/build/intermediates/exploded-aar/ViroSample/arcore_client/unspecified/res/values-nb/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding='utf-8' standalone='no'?>
+<resources>
+<!-- blaze-out/k8-opt/genfiles/third_party/arcore/java/com/google/ar/core/res_aar/values-no/strings.xml -->
+<eat-comment/>
+<string name="__arcore_cancel">Avbryt</string>
+<string name="__arcore_continue">Fortsett</string>
+<string name="__arcore_install_app">Denne appen krever den nyeste versjonen av ARCore.</string>
+<string name="__arcore_install_feature">Denne funksjonen krever den nyeste versjonen av ARCore.</string>
+<string name="__arcore_installing">Installerer ARCore …</string>
+</resources>


### PR DESCRIPTION
The "no" language tag has been deprecated for some years, and translations with it does not show up on newer Android phones, so I copied the values-no folder over to its primary successor tag "values-nb".